### PR TITLE
Avoid enforcing XTDB version onto our users

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,6 +1,5 @@
 ;;!zprint {:map {:hang? true :force-nl? true :key-order [:paths :deps :tasks] :key-value-options {:tasks {:map {:sort? true :justify? true}}}}}
 {:paths ["scripts"]
- :deps {}
  :min-bb-version "0.4.0"
  :tasks {check      {:depends [lint-check fmt-check]
                      :doc     "Check the code for problems."}
@@ -13,6 +12,8 @@
          lint-check {:doc  "Check code linting."
                      :task (shell "scripts/lint-clj.sh check")}
          test       {:doc  "Run the test suite."
-                     :task (clojure "-M:test" "--fail-fast" "unit")}
+                     :task (doseq [xtdb-alias [:1.21 :1.22 :1.23]]
+                             (println "\n⬇ Testing against XTDB" (name xtdb-alias) " ⬇")
+                             (clojure (str "-M" ":test" (str xtdb-alias)) "--fail-fast" "unit"))}
          test-watch {:doc  "Test files while watching the file system for changes."
                      :task (clojure "-M:test" "--fail-fast" "--watch" "unit")}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,9 @@
 {:paths ["src"]
- :deps {com.xtdb/xtdb-core {:mvn/version "1.21.0"}}
+ :deps {}
  :aliases
  {:test {:extra-paths ["test"]
-         :extra-deps {lambdaisland/kaocha {:mvn/version "1.70.1086"}
+         :extra-deps {com.xtdb/xtdb-core {:mvn/version "1.23.2"}
+                      lambdaisland/kaocha {:mvn/version "1.70.1086"}
                       org.slf4j/slf4j-nop {:mvn/version "1.7.36"}}
          :main-opts ["-m" "kaocha.runner"]}
   :build {:deps {io.github.seancorfield/build-clj {:git/tag "v0.8.2"
@@ -10,4 +11,8 @@
                                                    :exclusions [org.slf4j/slf4j-api
                                                                 ch.qos.logback/logback-classic]}
                  org.slf4j/slf4j-nop {:mvn/version "1.7.36"}}
-          :ns-default build}}}
+          :ns-default build}
+  ;; XTDB versions to test against
+  :1.21 {:override-deps {com.xtdb/xtdb-core {:mvn/version "1.21.0"}}}
+  :1.22 {:override-deps {com.xtdb/xtdb-core {:mvn/version "1.22.1"}}}
+  :1.23 {:override-deps {com.xtdb/xtdb-core {:mvn/version "1.23.2"}}}}}


### PR DESCRIPTION
We want to stop enforcing our own version of XTDB onto our users so we remove it from deps.edn. This patch also adds tests against the last three XTDB versions.