### PR TITLE
Do not pass entity id to XTDB when current entity is missing

### DIFF
--- a/src/com/cohesic/xtdb.clj
+++ b/src/com/cohesic/xtdb.clj
@@ -129,12 +129,10 @@ This version of the function is memoized."
 
   The :atomic? flag also adds a ::xt/match op if the current entity was present."
   [current-entity new-entity & {:keys [atomic? start-valid-time end-valid-time]}]
-  (let [entity-id (:xt/id current-entity)]
+  (let [entity-id (or (:xt/id current-entity) (:xt/id new-entity))]
     (if-not (= current-entity new-entity)
-      (let [match-op (->> [::xt/match entity-id current-entity start-valid-time]
-                          (filterv some?))
-            put-op (->> [::xt/put new-entity start-valid-time end-valid-time]
-                        (filterv some?))]
+      (let [match-op [::xt/match entity-id current-entity start-valid-time]
+            put-op [::xt/put new-entity start-valid-time end-valid-time]]
         (if atomic? [match-op put-op] [put-op]))
       [])))
 


### PR DESCRIPTION
This patch fixes a bug that was causing XTDB to throw when we could not find the current entity in the db and `:atomic?` is true (aka we use an ::xt/match).

We now take the :xt/id from *either* the current and the new entity.

This patch also removes the unnecessary `(filterv some?)` - XTDB already handles `nil`s gracefully.